### PR TITLE
Fixed javacpp version

### DIFF
--- a/samples/javacv-demo/build.gradle
+++ b/samples/javacv-demo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.bytedeco'
-version = '1.5.4-SNAPSHOT'
+version = '1.5.3'
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
Hi

I tried to run samples project(javacpp) but it failed because it couldn't find javacv version 1.5.4-SNAPSHOT. And it's expected because it doesn't exist in [maven central](https://mvnrepository.com/artifact/org.bytedeco/javacv-platform), the latest version is 1.5.3. I noticed this 7ac296d49acefa62761796aeb4d3e4180327deea comment where you've updated version to 1.5.4-SNAPSHOT, but seems that something has changed and it's not available anymore. So, you could either merge this quick fix or release the missed version - it's up to you. 

Thanks