### PR TITLE
Exit entire build command if skip was specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Honor the `skip` property in `BuildTask` ([pull #7](https://github.com/bytedeco/gradle-javacpp/issues/7))
  * Add `BuildExtension` helper for `maven-publish` and update zlib sample project
  * Add builds for Android to zlib sample project ([issue #5](https://github.com/bytedeco/gradle-javacpp/issues/5))
 

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildTask.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildTask.java
@@ -192,6 +192,12 @@ public class BuildTask extends DefaultTask {
 
     @TaskAction public void build() throws IOException, ClassNotFoundException, NoClassDefFoundError, InterruptedException, ParserException {
         Logger logger = new Slf4jLogger(Builder.class);
+
+        if (getSkip()) {
+            logger.info("Skipping execution of JavaCPP Builder");
+            return;
+        }
+
         Builder builder = new Builder(logger)
                 .classPaths(getClassPath())
                 .encoding(getEncoding())


### PR DESCRIPTION
As discussed in #6 this will now properly skip the build if `BuildTask.skip` is set to true.