### PR TITLE
Fix javacppBuildParser default value set issue

### DIFF
--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -135,7 +135,9 @@ public class BuildPlugin implements Plugin<Project> {
                     task.propertyKeysAndValues = new Properties();
                     task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
                 }
-                task.outputDirectory = main.getJava().getSrcDirs().iterator().next();
+                if(task.outputDirectory == null){
+                    task.outputDirectory = main.getJava().getSrcDirs().iterator().next();
+                }
                 task.dependsOn("javacppCompileJava");
                 task.doFirst(t -> { main.getJava().srcDir(task.outputDirectory); });
             });


### PR DESCRIPTION
> I think there is a problem in 'gradle-javacpp' plugin.
> 
> I used this plugin to multi gradle project(a.k.a sub project). like below structure.
> ```
> rootproject/build.gradle
> rootproject/settings.gradle
> rootproject/subproject_1/build.gradle
> rootproject/subproject_1/src/main/cpp
> rootproject/subproject_1/src/main/java
> ```
> 
> **rootproject/build.gradle**
> ```
> plugins {
>     id 'org.bytedeco.gradle-javacpp-build' version '1.5.5'
> }
> ...
> subprojects { subproject ->
>     apply plugin: 'org.bytedeco.gradle-javacpp-build'
> 
>     // This code can be more simpler like "javacppBuildParser { ... }".
>     tasks.withType(org.bytedeco.gradle.javacpp.BuildTask) {
>         if (it.name.equals("javacppBuildParser")) {
>             System.out.println("rootproject build.gradle set output directory changed to '$buildDir/generated/sources/javacpp'")
>             outputDirectory(file("$buildDir/generated/sources/javacpp"))
>         }
>     }
> }
> ```
> 
> **rootproject/settings.gradle**
> ```
> rootProject.name = "rootproject"
> include 'subproject_1'
> ```
> 
> **rootproject/subproject_1/build.gradle**
> ```
> ...
> javacppBuildParser {
>     System.out.println("subproject_1 build.gradle set output directory changed to '$buildDir/generated/sources/javacpp'")
>     outputDirectory(file("$buildDir/generated/sources/javacpp"))
> }
> ...
> 
> ```
> 
> ** And i execute 'javacppBuildParser' task. it works fine. **
> ```
> > Configure project :subproject_1
> rootproject build.gradle set output directory changed to 'rootproject/subproject_1/build/generated/sources/javacpp'
> subproject_1 build.gradle set output directory changed to 'rootproject/subproject_1/build/generated/sources/javacpp'
> ...
> > Task :subproject_1:javacppBuildParser
> jnijavacpp.cpp
> rootproject/subproject_1/build/generated/sources/javacpp/jnijavacpp.cpp(433): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
> ...
> ```
> (working on `rootproject/subproject_1/build/generated/sources/javacpp/` directory)
> 
> ** But If i remove `javacppBuildParser { ... }` code in subproject_1/build.gradle and then I execute 'javacppBuildParser' task, working like not set `outputDirectory`.**
> ```
> > Configure project :subproject_1
> rootproject build.gradle set output directory changed to 'rootproject/subproject_1/build/generated/sources/javacpp'
> ...
> > Task :subproject_1:javacppBuildParser
> jnijavacpp.cpp
> rootproject/subproject_1/src/main/java/jnijavacpp.cpp(433): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
> ...
> ```
> (working on `rootproject/subproject_1/src/main/java/` directory)
> 
> I think problem is this [code](https://github.com/bytedeco/gradle-javacpp/blob/7380cd9197ea06b8754aa512e69b283ddb307842/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java#L138)
> 
> Basically, root project configure execute before subproject configure.
> 
> So executed like this.
> 1. root project changed subproject_1's `outputDirectory`
> 2. BuildPlugin.java#L138 changed subproject's `outputDirectory` to default value.
> 3. sub project doesn't change subproject's `outputDirectory`.
> 
> As a result, root project's work(change `outputDirectory`) was ignored. because overwritten in step 2.
> 
> If the "BuildPlugin.java#L138" is only for set a default value. should do null check.


Fix this issue

