### PR TITLE
Improve JPMS support: linking native jars into the jlink image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
     id 'signing'
+    id 'me.champeau.mrjar' version "0.1"
 }
 
 group = 'org.bytedeco'
@@ -12,10 +13,16 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    gradlePluginPortal()
+}
+
+multiRelease {
+    targetVersions 8, 9
 }
 
 dependencies {
     api "org.bytedeco:javacpp:$version"
+    java9Implementation gradleApi()
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/src/main/java/org/bytedeco/gradle/javacpp/JavaCPPExtension.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/JavaCPPExtension.java
@@ -1,0 +1,32 @@
+package org.bytedeco.gradle.javacpp;
+
+import org.bytedeco.javacpp.Loader;
+import org.gradle.api.Project;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+public class JavaCPPExtension {
+
+    public List<String> platforms;
+
+    /**
+     * Comma-separated list of native modules for each source set.
+     */
+    public HashMap<String, String> nativeModulesOf = new HashMap<>();
+
+    public JavaCPPExtension(Project project) {
+        // Initialize platforms with javacppPlatform extra properties for backward compatibility.
+        Object javacppPlatform = project.findProperty("javacppPlatform");
+        platforms = new ArrayList<>();
+        if (javacppPlatform == null) {
+            platforms.add(Loader.Detector.getPlatform());
+        } else {
+            platforms.addAll(Arrays.asList(javacppPlatform.toString().split("\\s*,\\s*")));
+        }
+    }
+
+    public String getNativeModules() { return nativeModulesOf.get("main"); }
+}

--- a/src/main/java/org/bytedeco/gradle/javacpp/PlatformPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/PlatformPlugin.java
@@ -41,14 +41,12 @@ import org.gradle.api.Project;
  */
 public class PlatformPlugin implements Plugin<Project> {
     @Override public void apply(Project project) {
-        if (!project.hasProperty("javacppPlatform")) {
-            project.getExtensions().getExtraProperties().set("javacppPlatform", Loader.Detector.getPlatform());
-        }
+        JavaCPPExtension ext = project.getExtensions().create("javacpp", JavaCPPExtension.class, project);
 
         project.afterEvaluate(p -> {
-            p.getDependencies().getComponents().all(PlatformRule.class, rule -> {
-                rule.setParams(p.findProperty("javacppPlatform"));
-            });
+          p.getDependencies().getComponents().all(PlatformRule.class, rule -> rule.setParams(ext.platforms));
+
+          VersionSpecific.installNativeModulesComputation(project, ext);
         });
     }
 }

--- a/src/main/java/org/bytedeco/gradle/javacpp/PlatformRule.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/PlatformRule.java
@@ -22,7 +22,6 @@
 package org.bytedeco.gradle.javacpp;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import javax.inject.Inject;
@@ -51,8 +50,8 @@ class PlatformRule implements ComponentMetadataRule {
     final List<String> platform;
 
     /** Takes a comma-separated list of platform names to keep. */
-    @Inject public PlatformRule(String platform) {
-        this.platform = Arrays.asList(platform.split(","));
+    @Inject public PlatformRule(List<String> platform) {
+        this.platform = platform;
     }
 
     @Override public void execute(ComponentMetadataContext context) {

--- a/src/main/java/org/bytedeco/gradle/javacpp/VersionSpecific.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/VersionSpecific.java
@@ -1,0 +1,8 @@
+package org.bytedeco.gradle.javacpp;
+
+import org.gradle.api.Project;
+
+abstract class VersionSpecific {
+  static void installNativeModulesComputation(Project project, JavaCPPExtension ext) {
+  }
+}

--- a/src/main/java9/org/bytedeco/gradle/javacpp/VersionSpecific.java
+++ b/src/main/java9/org/bytedeco/gradle/javacpp/VersionSpecific.java
@@ -1,0 +1,39 @@
+package org.bytedeco.gradle.javacpp;
+
+import org.gradle.api.Project;
+import org.gradle.api.tasks.SourceSetContainer;
+
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
+import java.util.stream.Collectors;
+
+abstract class VersionSpecific {
+  static void installNativeModulesComputation(Project project, JavaCPPExtension ext) {
+
+    SourceSetContainer sourceSets = (SourceSetContainer) project.getProperties().get("sourceSets");
+    sourceSets.all(sourceSet -> {
+      String taskName = sourceSet.getClassesTaskName();
+      project
+          .getTasks()
+          .findByName(taskName)
+          .doLast(task -> ext.nativeModulesOf.put(sourceSet.getName(),
+              sourceSet
+                  .getRuntimeClasspath()
+                  .getFiles()
+                  .stream()
+                  .map(file -> {
+                    ModuleDescriptor moduleDescriptor =
+                        ModuleFinder.of(file.toPath())
+                            .findAll()
+                            .stream()
+                            .findFirst()
+                            .map(ModuleReference::descriptor)
+                            .orElse(null);
+                    return moduleDescriptor == null ? null : moduleDescriptor.name();
+                  })
+                  .filter(s -> s != null && ext.platforms.stream().map(platform -> platform.replace('-', '.')).anyMatch(s::contains))
+                  .collect(Collectors.joining(","))));
+    });
+  }
+}


### PR DESCRIPTION
When running JPMS applications, JavaCPP users should only declare, in their module descriptor, the platform-independent module they need. For instance:
```
requires org.bytedeco.opencv
```
The platform-dependent native modules need to be added to the module graph with `--add-modules` command line argument when running the application, and when building an image with jlink.

Since the module path is automatically populated with the needed native jars by Maven (using the `javacpp.platform` property)
or by the Gradle plugin (using the `javacppPlatform` extra property), `--add-modules ALL-MODULE-PATH` is enough for running the application.

For building a JLink image with Maven, we can use the Apache Maven JLink plugin that automatically generates a `--add-modules` from the modules found in the module path.
But with Gradle, we have nothing similar. If we use the JavaFX Gradle plugin or the Badass jlink plugin, there is no such auto-generated `--add-modules` and thus the native modules are not added to the image.
If we configure Badass jlink plugin with `--add-module ALL-MODULE-PATH`, the image will contain all JavaCPP native modules
but also all the standard modules from the JDK, ruining most of the interest of building a custom runtime with jlink.

This PR adds the computation of a native module list that can be used in the Badass JLink plugin configuration to generate a proper `--add-module` argument.
It defines a javacpp extension to the platform plugin that contains the `plaforms` property and the `nativeModules` property.
The `nativeModules` property is computed during execution after the `classes` task (since it uses the runtime classpath, which can be modified during task execution), so must be added to the jlink task configuration in a `doFirst` block.
The `platforms` property replaces the `javacppPlatforms` extension property, but configuring the extra property is still supported for backward compatibility. Directly using the `platforms` property in a `javacpp` DSL block looks just a bit better.
More configurations for the JavaCPP plugin could be added later in this extension.
Here is an example of build script with kotlin syntax:

```Kotlin
plugins {
    application
    id("org.bytedeco.gradle-javacpp-platform") version "1.5.8-SNAPSHOT"
    id("org.beryx.jlink") version "2.25.0"
}

javacpp {
  platforms = listOf("linux-x86_64")
}

dependencies {
    implementation("org.bytedeco:opencv-platform:4.5.5-1.5.7")
}

group = "org.bytedeco"
version = "1.0-SNAPSHOT"
description = "gradle-jlink-sample"

application {
    mainModule.set("org.bytedeco.sample")
    mainClass.set("org.bytedeco.sample.Application")
    applicationDefaultJvmArgs = listOf("--add-modules", "ALL-MODULE-PATH")
}

tasks.jlink {
  doFirst {
    jlink {
      options.set(listOf("--add-modules", javacpp.nativeModules))
      launcher {
        jvmArgs = listOf("--add-modules", javacpp.nativeModules)
      }
    }
  }
}
```

Note that the JavaFX gradle plugin doesn't allow to configure `--add-modules` for jlink, and is not needed anyway to run or link applications using JavaFX.