### PR TITLE
Improve JPMS support: preinstall native libraries in jlink runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
     id 'signing'
+    id 'me.champeau.mrjar' version "0.1"
 }
 
 group = 'org.bytedeco'
@@ -12,11 +13,24 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    gradlePluginPortal()
+}
+
+multiRelease {
+    targetVersions 8, 11
 }
 
 dependencies {
     api "org.bytedeco:javacpp:$version"
     testImplementation 'junit:junit:4.13.2'
+    java11Implementation gradleApi()
+    java11Implementation "org.bytedeco:javacpp:$version"
+
+    // Needed for plugin compilation:
+    java11Implementation "org.javassist:javassist:3.28.0-GA"
+    // Needed or the plugin pom won't list this dependency
+    // See https://github.com/melix/mrjar-gradle-plugin/issues/1
+    implementation "org.javassist:javassist:3.28.0-GA"
 }
 
 gradlePlugin {

--- a/src/main/java/org/bytedeco/gradle/javacpp/PlatformPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/PlatformPlugin.java
@@ -50,5 +50,7 @@ public class PlatformPlugin implements Plugin<Project> {
                 rule.setParams(p.findProperty("javacppPlatform"));
             });
         });
+
+        VersionSpecific.registerBuildNativeModuleTask(project);
     }
 }

--- a/src/main/java/org/bytedeco/gradle/javacpp/VersionSpecific.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/VersionSpecific.java
@@ -1,0 +1,10 @@
+package org.bytedeco.gradle.javacpp;
+
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskInstantiationException;
+
+abstract class VersionSpecific {
+  static void registerBuildNativeModuleTask(Project project) {
+    throw new TaskInstantiationException("The javacppBuildNativeModule task requires Java 11+");
+  }
+}

--- a/src/main/java11/org/bytedeco/gradle/javacpp/BuildNativeModuleTask.java
+++ b/src/main/java11/org/bytedeco/gradle/javacpp/BuildNativeModuleTask.java
@@ -1,0 +1,91 @@
+package org.bytedeco.gradle.javacpp;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.plugins.JavaApplication;
+import org.gradle.api.tasks.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.spi.ToolProvider;
+
+public class BuildNativeModuleTask extends DefaultTask {
+
+    @Classpath @InputFiles
+    FileCollection getRuntimeClasspath() {
+        SourceSetContainer ssc = (SourceSetContainer) getProject().getProperties().get("sourceSets");
+        return ssc.getByName("main").getRuntimeClasspath();
+    }
+
+    @OutputFile
+    File getModuleFile() {
+        return new File(new File(getProject().getBuildDir(), "native"), "native.jmod");
+    }
+
+    @TaskAction
+    void impl() throws IOException {
+        File buildDir = getProject().getBuildDir();
+        File nativeDir = new File(buildDir, "native");
+        Path nativePath = nativeDir.toPath();
+        Path libPath= nativePath.resolve("lib");
+        Path classesPath= nativePath.resolve("classes");
+        Path srcPath= nativePath.resolve("java");
+
+        // We should support adding other main classes if the application has several launchers with different main
+        // classes
+        JavaApplication javaApplication = getProject().getExtensions().findByType(JavaApplication.class);
+        if (javaApplication == null)
+            throw new GradleException("'application' has not been configured");
+        String mainClass = javaApplication.getMainClass().getOrNull();
+        if (mainClass == null)
+            throw new GradleException("main class has not been set in the 'application' configuration");
+
+        Files.createDirectories(libPath);
+        clearDirectory(libPath);
+        Files.createDirectories(srcPath);
+        clearDirectory(srcPath);
+        Files.writeString(srcPath.resolve("module-info.java"), "module org.bytedeco.javacpp.libs {}");
+
+        BytecodeAnalyzer bca = new BytecodeAnalyzer(getRuntimeClasspath(), getProject());
+
+        List<String> deps = bca.getJavaCPPDependencies(mainClass);
+
+        bca.loadClasses(deps, libPath, getLogger());
+
+        ToolProvider javacTool = ToolProvider.findFirst("javac").orElseThrow();
+        int res = javacTool.run(System.out, System.err,
+            "-d", classesPath.toString(),
+            "--release", "11",
+            srcPath.resolve("module-info.java").toString());
+        if (res != 0) throw new GradleException("Compilation of module-info.java failed");
+
+        File jmodFile = getModuleFile();
+        //noinspection ResultOfMethodCallIgnored
+        jmodFile.delete();
+        ToolProvider jmodTool = ToolProvider.findFirst("jmod").orElseThrow();
+        res = jmodTool.run(System.out, System.err,
+            "create",
+            "--libs", libPath.toString(),
+            "--class-path", classesPath.toString(),
+            jmodFile.getAbsolutePath()
+        );
+        if (res != 0) throw new GradleException("Creation of jmod failed");
+    }
+
+    private void clearDirectory(Path libPath) throws IOException {
+        Files.list(libPath).forEach(p -> {
+            if (Files.isDirectory(p))
+                throw new GradleException("Unexpected directory " + p);
+            try {
+                Files.delete(p);
+            } catch (IOException e) {
+                throw new GradleException("Cannot delete file ", e);
+            }
+        });
+    }
+
+}

--- a/src/main/java11/org/bytedeco/gradle/javacpp/BytecodeAnalyzer.java
+++ b/src/main/java11/org/bytedeco/gradle/javacpp/BytecodeAnalyzer.java
@@ -1,0 +1,133 @@
+package org.bytedeco.gradle.javacpp;
+
+import javassist.*;
+import javassist.bytecode.ClassFile;
+import javassist.bytecode.ConstPool;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.logging.Logger;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+class BytecodeAnalyzer {
+
+    private final FileCollection runtimePath;
+    private final ClassPool cp;
+    private final String platform;
+
+    BytecodeAnalyzer(FileCollection runtimePath, Project project) {
+        this.runtimePath = runtimePath;
+
+        cp = new ClassPool();
+
+        try {
+            cp.appendPathList(runtimePath.getAsPath());
+        } catch (NotFoundException e) {
+            throw new GradleException("Path component not found", e);
+        }
+
+        platform = (String) project.findProperty("javacppPlatform");
+        if (platform == null || platform.indexOf(',') >= 0)
+            throw new GradleException("The javacppPlatform must contain a single platform to build the native module");
+    }
+
+    List<String> getJavaCPPDependencies(String main) {
+
+        HashSet<String> dependencies = new HashSet<>();
+        HashSet<String> toAnalyze = new HashSet<>();
+        ArrayList<String> javacppClasses = new ArrayList<>();
+        toAnalyze.add(main);
+
+        while (!toAnalyze.isEmpty()) {
+            HashSet<String> thisDeps = new HashSet<>();
+            for (String c : toAnalyze) {
+                try {
+                    CtClass cc = cp.get(c);
+                    if (cc.isFrozen()) continue;
+                    ClassFile cf = cc.getClassFile();
+                    // Can we check for something more specific ?
+                    if (cc.hasAnnotation("org.bytedeco.javacpp.annotation.Properties"))
+                        javacppClasses.add(c);
+
+                    ConstPool constPool = cf.getConstPool();
+                    for (int ix = 1, size = constPool.getSize(); ix < size; ix++) {
+                        int descriptorIndex;
+                        switch (constPool.getTag(ix)) {
+                            case ConstPool.CONST_Class:
+                                thisDeps.add(constPool.getClassInfo(ix));
+                            default:
+                                continue;
+                            case ConstPool.CONST_NameAndType:
+                                descriptorIndex = constPool.getNameAndTypeDescriptor(ix);
+                                break;
+                            case ConstPool.CONST_MethodType:
+                                descriptorIndex = constPool.getMethodTypeInfo(ix);
+                        }
+                        String desc = constPool.getUtf8Info(descriptorIndex);
+                        for (int p = 0; p < desc.length(); p++)
+                            if (desc.charAt(p) == 'L')
+                                thisDeps.add(desc.substring(++p, p = desc.indexOf(';', p)).replace('/', '.'));
+                    }
+                } catch (NotFoundException ignored) {
+                    // java.*, javax.*
+                }
+            }
+
+            toAnalyze.clear();
+
+            for (String c : thisDeps) {
+                if (!dependencies.contains(c)) {
+                    dependencies.add(c);
+                    toAnalyze.add(c);
+                }
+            }
+        }
+
+        return javacppClasses;
+    }
+
+    void loadClasses(List<String> classes, Path cacheDir, Logger logger) {
+        System.setProperty("javacpp.platform", platform);
+        System.setProperty("org.bytedeco.javacpp.cachedir.nosubdir", "true");
+        System.setProperty("org.bytedeco.javacpp.cachedir", cacheDir.toString());
+
+        ArrayList<URL> urls = new ArrayList<>();
+        for (File jar : runtimePath) {
+            try {
+                urls.add(jar.toURI().toURL());
+            } catch (MalformedURLException e) {
+                logger.warn("Malformed path component", e);
+            }
+        }
+        URLClassLoader resourceLoader = new URLClassLoader(urls.toArray(new URL[0]));
+
+        // Javassist will load classes and delegate resource loading to resourceLoader
+        javassist.Loader jLoader = new javassist.Loader(resourceLoader, cp);
+
+        try {
+            Class<?> javaCPPLoader = jLoader.loadClass("org.bytedeco.javacpp.Loader");
+            Method load = javaCPPLoader.getMethod("load", Class[].class);
+
+            for (String cn : classes) {
+                try {
+                    Class<?> c = jLoader.loadClass(cn);
+                    load.invoke(javaCPPLoader, new Object[]{new Class[]{c}});
+                } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException ex) {
+                    logger.warn("Cannot load "+cn, ex);
+                }
+            }
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            throw new GradleException("Cannot load JavaCPP Loader", e);
+        }
+    }
+}

--- a/src/main/java11/org/bytedeco/gradle/javacpp/VersionSpecific.java
+++ b/src/main/java11/org/bytedeco/gradle/javacpp/VersionSpecific.java
@@ -1,0 +1,9 @@
+package org.bytedeco.gradle.javacpp;
+
+import org.gradle.api.Project;
+
+abstract class VersionSpecific {
+  static void registerBuildNativeModuleTask(Project project) {
+    project.getTasks().register("javacppBuildNativeModule", BuildNativeModuleTask.class);
+  }
+}


### PR DESCRIPTION
Here is an attempt to improve support for creating jlink image by pre-extracting the native libraries in the runtime.
It has the following advantages compared to linking native jars :
* it's more developer friendly since we avoid the mess of adding the native jars to the image with the `--add-modules` command line argument of jlink, with all possible variations (see [this PR](https://github.com/bytedeco/gradle-javacpp/pull/20)).
* it's more end-user friendly since we don't need to extract the libraries to a hidden, never cleaned, cache in its home directory.

This PR defines a new Gradle task `javacppBuildNativeModule` which performs the following steps:
1) Obtain the module path from the `main` source set (as computed by the `java` plugin), and the main class from the `application` configuration.
2) Determine the set of java class dependencies by walking from the main class, using the Javassist bytecode editor and its ability to read the constant pool table. This is better than reading all classes from the whole module path since we end up with a much smaller set. It also avoids the case where some classes in the presets need other presets not included in the artifact dependencies (seen with opencv  with some classes needing cpython).
3) Retain from this set only the classes annotated with the JavaCPP `Properties`. 
4) Call JavaCPP `Loader.load` on each of the retained classes, with  system properties `org.bytedeco.javacpp.cachedir` and `org.bytedeco.javacpp.cachedir.nosubdir` set to populate a temporary `lib` directory with all, and only, the required native libraries.
5) Compile a `module-info.java` containing `module org.bytedeco.javacpp.libs {}`
6) Build a jmod containing this module descriptor and the content of the `lib` directory. This allows to delegate to  jlink the work of installing the native libraries in the proper runtime directory, depending on the platform.
7) Call jlink with the jmod added to the module path and `--add-modules org.bytedeco.javacpp.libs`.

Here is an example build script using kotlin DSL:

```Kotlin

plugins {
    application
    id("org.bytedeco.gradle-javacpp-platform") version "1.5.8-SNAPSHOT"
    id("org.beryx.jlink") version "2.25.0"
}

extra["javacppPlatform"] = "linux-x86_64"

dependencies {
    implementation("org.bytedeco:opencv-platform:4.5.5-1.5.7")
}

group = "org.bytedeco"
version = "1.0-SNAPSHOT"
description = "gradle-jlink-sample"

application {
    mainModule.set("org.bytedeco.sample")
    mainClass.set("org.bytedeco.sample.Application")
    applicationDefaultJvmArgs = listOf("--add-modules", "ALL-MODULE-PATH")
}

jlink {
    addExtraModulePath("build/native/native.jmod");
    addOptions("--add-modules", "org.bytedeco.javacpp.libs")
}

tasks.named("jlink") {
        dependsOn("javacppBuildNativeModule")
}
```

Tested and working on a simple application using opencv and javafx, but for some obscure reasons I didn't investigate:
* multiple versions of the same library are installed (like `libjniopenblas1.so`, `libjniopenblas2.so`...).
* `libopenblas_nolapack.so.0` is still copied in `~/.javacpp` altough it's present in the runtime.