### PR TITLE
Update Gradle Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+ * Fix compatibility with Gradle 8.x ([pull #31](https://github.com/bytedeco/gradle-javacpp/issues/31))
+
 ### June 6, 2023 version 1.5.9
  * Fix compatibility with Gradle 7.6.x ([issue #28](https://github.com/bytedeco/gradle-javacpp/issues/28))
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use Gradle JavaCPP, you will need to download and install the following softw
    * OpenJDK  http://openjdk.java.net/install/  or
    * Oracle JDK  http://www.oracle.com/technetwork/java/javase/downloads/  or
    * IBM JDK  http://www.ibm.com/developerworks/java/jdk/
- * Gradle 5.0 or newer: https://gradle.org/releases/
+ * Gradle 6.0 or newer: https://gradle.org/releases/
 
 
 Getting Started

--- a/build.gradle
+++ b/build.gradle
@@ -40,11 +40,11 @@ gradlePlugin {
 jar {
     manifest {
         attributes 'Implementation-Title': 'Gradle JavaCPP',
-                   'Implementation-Vendor': 'Bytedeco',
-                   'Implementation-Version': project.version,
-                   'Specification-Title': 'Gradle JavaCPP',
-                   'Specification-Vendor': 'Bytedeco',
-                   'Specification-Version': project.version
+                'Implementation-Vendor': 'Bytedeco',
+                'Implementation-Version': project.version,
+                'Specification-Title': 'Gradle JavaCPP',
+                'Specification-Vendor': 'Bytedeco',
+                'Specification-Version': project.version
     }
 }
 
@@ -64,12 +64,16 @@ javadoc {
 //}
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+// Do not work after Gradle 5.1.
+//    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
     from javadoc.destinationDir
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
+// Do not work after Gradle 5.1.
+//    classifier = 'sources'
+    archiveClassifier = 'sources'
     from sourceSets.main.allSource
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,29 +57,9 @@ javadoc {
                      'http://junit.org/junit4/javadoc/4.13.2']
 }
 
-//doesn't work with Gradle 5.x
-//java {
-//    withJavadocJar()
-//    withSourcesJar()
-//}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-// Do not work after Gradle 5.1.
-//    classifier = 'javadoc'
-    archiveClassifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-// Do not work after Gradle 5.1.
-//    classifier = 'sources'
-    archiveClassifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-artifacts {
-    archives javadocJar
-    archives sourcesJar
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 def pomClosure = {
@@ -121,8 +101,6 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
-            artifact javadocJar
-            artifact sourcesJar
             pom pomClosure
         }
         buildPluginMarkerMaven(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -40,11 +40,11 @@ gradlePlugin {
 jar {
     manifest {
         attributes 'Implementation-Title': 'Gradle JavaCPP',
-                'Implementation-Vendor': 'Bytedeco',
-                'Implementation-Version': project.version,
-                'Specification-Title': 'Gradle JavaCPP',
-                'Specification-Vendor': 'Bytedeco',
-                'Specification-Version': project.version
+                   'Implementation-Vendor': 'Bytedeco',
+                   'Implementation-Version': project.version,
+                   'Specification-Title': 'Gradle JavaCPP',
+                   'Specification-Vendor': 'Bytedeco',
+                   'Specification-Version': project.version
     }
 }
 
@@ -169,4 +169,3 @@ signing {
         sign publishing.publications.platformPluginMarkerMaven
     }
 }
-

--- a/samples/zlib/build.gradle
+++ b/samples/zlib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'org.bytedeco'
-version = "1.2.13-$javacppVersion"
+version = "1.3-$javacppVersion"
 
 repositories {
     mavenLocal()

--- a/samples/zlib/build.sh
+++ b/samples/zlib/build.sh
@@ -4,11 +4,11 @@ set -e
 mkdir -p build/$PLATFORM
 cd build/$PLATFORM
 
-ZLIB_VERSION=1.2.13
+ZLIB_VERSION=1.3
 if [[ ! -e "zlib-$ZLIB_VERSION.tar.gz" ]]; then
     curl -L "http://zlib.net/zlib-$ZLIB_VERSION.tar.gz" -o "zlib-$ZLIB_VERSION.tar.gz"
 fi
-echo "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30  zlib-$ZLIB_VERSION.tar.gz" | shasum -a 256 -c -
+echo "ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e  zlib-$ZLIB_VERSION.tar.gz" | shasum -a 256 -c -
 
 echo "Decompressing archives..."
 tar --totals -xf "zlib-$ZLIB_VERSION.tar.gz"

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildExtension.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildExtension.java
@@ -22,13 +22,6 @@
 package org.bytedeco.gradle.javacpp;
 
 import groovy.util.Node;
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.List;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.XmlProvider;
@@ -36,6 +29,8 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.internal.project.DefaultProject;
+import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.plugins.BasePluginConvention;
 import org.gradle.api.publish.maven.MavenArtifact;
 import org.gradle.api.publish.maven.MavenPom;
@@ -43,16 +38,48 @@ import org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Provides helper methods intended to be used with the "maven-publish" plugin.
  *
  * @author Samuel Audet
  */
 public class BuildExtension {
+    private static final Constructor<FileBasedMavenArtifact> compatibleArtifactConstructor;
+    private static final boolean isLegacy;
     private final Logger logger = LoggerFactory.getLogger(BuildExtension.class);
-
     BuildPlugin plugin;
     Project project;
+
+    static {
+        boolean legacyCheck;
+        Constructor<FileBasedMavenArtifact> compatibleConstructor;
+        try {
+            // If gradle version is lower than 6.2, use legacy constructor.
+            compatibleConstructor = FileBasedMavenArtifact.class.getConstructor(File.class);
+            legacyCheck = true;
+        } catch (NoSuchMethodException e) {
+            try {
+                // If gradle version is equals or higher than 6.2, use latest constructor.
+                compatibleConstructor = FileBasedMavenArtifact.class.getConstructor(File.class, TaskDependencyFactory.class);
+                legacyCheck = false;
+            } catch (NoSuchMethodException e2) {
+                // If no compatible constructor found, constructor signature modified on latest version and do not compatible with this code.
+                // Throw exception to prevent build.
+                throw new RuntimeException("Could not find constructor for FileBasedMavenArtifact (Incompatible with this gradle version)", e);
+            }
+        }
+        isLegacy = legacyCheck;
+        compatibleArtifactConstructor = compatibleConstructor;
+    }
 
     public BuildExtension(BuildPlugin plugin) {
         this.plugin = plugin;
@@ -78,7 +105,7 @@ public class BuildExtension {
             // Temporarily rename our project to prevent Gradle from resolving the artifacts to project dependencies without files.
             Field nameField = DefaultProject.class.getDeclaredField("name");
             nameField.setAccessible(true);
-            String name = (String)nameField.get(project);
+            String name = (String) nameField.get(project);
             nameField.set(project, name + "-renamed");
             for (ResolvedDependency rd : configuration.getResolvedConfiguration().getLenientConfiguration().getFirstLevelModuleDependencies()) {
                 if (rd.getModuleGroup().equals(project.getGroup()) && rd.getModuleName().equals(name)) {
@@ -88,7 +115,8 @@ public class BuildExtension {
                                 File in = ra.getFile();
                                 File out = new File(libsDir, in.getName());
                                 Files.copy(in.toPath(), out.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                                MavenArtifact ma = new FileBasedMavenArtifact(out);
+                                MavenArtifact ma = isLegacy ? compatibleArtifactConstructor.newInstance(out) :
+                                        compatibleArtifactConstructor.newInstance(out, DefaultTaskDependencyFactory.withNoAssociatedProject());
                                 ma.setClassifier(ra.getClassifier());
                                 artifacts.add(ma);
                             } catch (RuntimeException e) {
@@ -105,169 +133,174 @@ public class BuildExtension {
         return artifacts;
     }
 
-    /** Returns {@code xmlAction(configuration, null)}. */
+    /**
+     * Returns {@code xmlAction(configuration, null)}.
+     */
     public Action<? extends XmlProvider> xmlAction(Configuration configuration) {
         return xmlAction(configuration, null);
     }
+
     /**
      * Returns object to be called with {@link MavenPom#withXml(Action)} to create a pom.xml file for "-platform" artifacts.
      *
      * @param configuration containing dependencies to use
-     * @param extension like "-gpl", "-gpu", "-python", etc (optional)
+     * @param extension     like "-gpl", "-gpu", "-python", etc (optional)
      * @return an {@link Action} that fills up an {@link XmlProvider}
      * @see PlatformPlugin
      * @see <a href="https://github.com/bytedeco/javacpp-presets/wiki/Reducing-the-Number-of-Dependencies">Reducing the Number of Dependencies</a>
      */
     public Action<? extends XmlProvider> xmlAction(final Configuration configuration, final String extension) {
-        return new Action<XmlProvider>() { public void execute(XmlProvider xml) {
-            String[] allPlatforms = {"android-arm", "android-arm64", "android-x86", "android-x86_64",
-                                     "ios-arm", "ios-arm64", "ios-x86", "ios-x86_64",
-                                     "linux-armhf", "linux-arm64", "linux-ppc64le", "linux-x86", "linux-x86_64",
-                                     "macosx-arm64", "macosx-x86_64", "windows-x86", "windows-x86_64"};
+        return new Action<XmlProvider>() {
+            public void execute(XmlProvider xml) {
+                String[] allPlatforms = {"android-arm", "android-arm64", "android-x86", "android-x86_64",
+                        "ios-arm", "ios-arm64", "ios-x86", "ios-x86_64",
+                        "linux-armhf", "linux-arm64", "linux-ppc64le", "linux-x86", "linux-x86_64",
+                        "macosx-arm64", "macosx-x86_64", "windows-x86", "windows-x86_64"};
 
-            String[] osNameFrom = {"linux", "mac os x", "windows"};
-            String[] osNameKernel = {"linux", "darwin", "windows"};
-            String[] osNameType = {"name", "name", "family"};
-            String[] osNameTo = {"linux", "macosx", "windows"};
+                String[] osNameFrom = {"linux", "mac os x", "windows"};
+                String[] osNameKernel = {"linux", "darwin", "windows"};
+                String[] osNameType = {"name", "name", "family"};
+                String[] osNameTo = {"linux", "macosx", "windows"};
 
-            String[] osArchFrom = {"arm", "aarch64", "armv8", "ppc64le", "i386", "i486", "i586", "i686", "amd64", "x86-64"};
-            String[] osArchTo = {"armhf", "arm64", "arm64", "ppc64le", "x86", "x86", "x86", "x86", "x86_64", "x86_64"};
+                String[] osArchFrom = {"arm", "aarch64", "armv8", "ppc64le", "i386", "i486", "i586", "i686", "amd64", "x86-64"};
+                String[] osArchTo = {"armhf", "arm64", "arm64", "ppc64le", "x86", "x86", "x86", "x86", "x86_64", "x86_64"};
 
-            ArrayList<String> platforms = new ArrayList<String>();
-            Node propertiesNode = xml.asNode().appendNode("properties");
-            Node dependenciesNode = xml.asNode().appendNode("dependencies");
-            for (ResolvedDependency rd : configuration.getResolvedConfiguration().getLenientConfiguration().getFirstLevelModuleDependencies()) {
-                if (rd.getModuleGroup().equals(project.getGroup()) && rd.getModuleName().equals(project.getName())) {
-                    Node dependencyNode = dependenciesNode.appendNode("dependency");
-                    dependencyNode.appendNode("groupId", rd.getModuleGroup());
-                    dependencyNode.appendNode("artifactId", rd.getModuleName());
-                    dependencyNode.appendNode("version", rd.getModuleVersion());
-                }
-                for (ResolvedArtifact ra : rd.getModuleArtifacts()) {
-                    Node dependencyNode = dependenciesNode.appendNode("dependency");
-                    dependencyNode.appendNode("groupId", rd.getModuleGroup());
-                    dependencyNode.appendNode("artifactId", rd.getModuleName());
-                    dependencyNode.appendNode("version", rd.getModuleVersion());
-                    if (ra.getClassifier() != null) {
-                        String platform = ra.getClassifier();
-                        if (extension != null && platform.endsWith(extension)) {
-                            platform = platform.substring(0, platform.length() - extension.length());
+                ArrayList<String> platforms = new ArrayList<String>();
+                Node propertiesNode = xml.asNode().appendNode("properties");
+                Node dependenciesNode = xml.asNode().appendNode("dependencies");
+                for (ResolvedDependency rd : configuration.getResolvedConfiguration().getLenientConfiguration().getFirstLevelModuleDependencies()) {
+                    if (rd.getModuleGroup().equals(project.getGroup()) && rd.getModuleName().equals(project.getName())) {
+                        Node dependencyNode = dependenciesNode.appendNode("dependency");
+                        dependencyNode.appendNode("groupId", rd.getModuleGroup());
+                        dependencyNode.appendNode("artifactId", rd.getModuleName());
+                        dependencyNode.appendNode("version", rd.getModuleVersion());
+                    }
+                    for (ResolvedArtifact ra : rd.getModuleArtifacts()) {
+                        Node dependencyNode = dependenciesNode.appendNode("dependency");
+                        dependencyNode.appendNode("groupId", rd.getModuleGroup());
+                        dependencyNode.appendNode("artifactId", rd.getModuleName());
+                        dependencyNode.appendNode("version", rd.getModuleVersion());
+                        if (ra.getClassifier() != null) {
+                            String platform = ra.getClassifier();
+                            if (extension != null && platform.endsWith(extension)) {
+                                platform = platform.substring(0, platform.length() - extension.length());
+                            }
+                            dependencyNode.appendNode("classifier", "${javacpp.platform." + platform + "}");
+                            platforms.add(platform);
                         }
-                        dependencyNode.appendNode("classifier", "${javacpp.platform." + platform + "}");
-                        platforms.add(platform);
                     }
                 }
-            }
 
-            propertiesNode.appendNode("javacpp.platform.extension", extension != null ? extension : "");
-            for (String platform : platforms) {
-                propertiesNode.appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
-            }
+                propertiesNode.appendNode("javacpp.platform.extension", extension != null ? extension : "");
+                for (String platform : platforms) {
+                    propertiesNode.appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
+                }
 
-            Node profilesNode = xml.asNode().appendNode("profiles");
-            Node profileNode = profilesNode.appendNode("profile");
-            profileNode.appendNode("id", "javacpp-platform-default");
-            profileNode.appendNode("activation").appendNode("property").appendNode("name", "!javacpp.platform");
-            propertiesNode = profileNode.appendNode("properties");
-            propertiesNode.appendNode("javacpp.platform", "${os.name}-${os.arch}");
-
-            profileNode = profilesNode.appendNode("profile");
-            profileNode.appendNode("id", "javacpp-platform-custom");
-            profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform");
-            propertiesNode = profileNode.appendNode("properties");
-            for (String profilePlatform : platforms) {
-                propertiesNode.appendNode("javacpp.platform." + profilePlatform, "${javacpp.platform}${javacpp.platform.extension}");
-            }
-
-            profileNode = profilesNode.appendNode("profile");
-            profileNode.appendNode("id", "javacpp-platform-host");
-            profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.host");
-            propertiesNode = profileNode.appendNode("properties");
-            propertiesNode.appendNode("javacpp.platform", "${os.name}-${os.arch}${javacpp.platform.extension}");
-            for (String profilePlatform : platforms) {
-                propertiesNode.appendNode("javacpp.platform." + profilePlatform, "${os.name}-${os.arch}${javacpp.platform.extension}");
-            }
-
-            profileNode = profilesNode.appendNode("profile");
-            profileNode.appendNode("id", "javacpp.platform.custom-true");
-            profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.custom");
-            propertiesNode = profileNode.appendNode("properties");
-            propertiesNode.appendNode("javacpp.platform", "");
-            for (String profilePlatform : platforms) {
-                propertiesNode.appendNode("javacpp.platform." + profilePlatform, "");
-            }
-
-            profileNode = profilesNode.appendNode("profile");
-            profileNode.appendNode("id", "javacpp-platform-none");
-            profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.none");
-            propertiesNode = profileNode.appendNode("properties");
-            propertiesNode.appendNode("javacpp.platform", "");
-            for (String profilePlatform : platforms) {
-                propertiesNode.appendNode("javacpp.platform." + profilePlatform, "");
-            }
-
-            for (String platform : platforms) {
-                profileNode = profilesNode.appendNode("profile");
-                profileNode.appendNode("id", "javacpp-platform-" + platform);
-                Node activationPropertyNode = profileNode.appendNode("activation").appendNode("property");
-                activationPropertyNode.appendNode("name", "javacpp.platform");
-                activationPropertyNode.appendNode("value", platform);
+                Node profilesNode = xml.asNode().appendNode("profiles");
+                Node profileNode = profilesNode.appendNode("profile");
+                profileNode.appendNode("id", "javacpp-platform-default");
+                profileNode.appendNode("activation").appendNode("property").appendNode("name", "!javacpp.platform");
                 propertiesNode = profileNode.appendNode("properties");
-                propertiesNode.appendNode("javacpp.platform", platform);
+                propertiesNode.appendNode("javacpp.platform", "${os.name}-${os.arch}");
+
+                profileNode = profilesNode.appendNode("profile");
+                profileNode.appendNode("id", "javacpp-platform-custom");
+                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform");
+                propertiesNode = profileNode.appendNode("properties");
                 for (String profilePlatform : platforms) {
-                    propertiesNode.appendNode("javacpp.platform." + profilePlatform,
-                            platform == profilePlatform ? "${javacpp.platform}${javacpp.platform.extension}" : "");
+                    propertiesNode.appendNode("javacpp.platform." + profilePlatform, "${javacpp.platform}${javacpp.platform.extension}");
                 }
-            }
 
-            // Profiles to modify the transitive dependencies when picked up from other pom.xml files, for example:
-            // mvn -Djavacpp.platform.custom -Djavacpp.platform.host -Djavacpp.platform.linux-x86_64 -Djavacpp.platform.windows-x86_64 ...
-            for (String platform : platforms) {
                 profileNode = profilesNode.appendNode("profile");
-                profileNode.appendNode("id", "javacpp.platform." + platform + "-true");
-                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform." + platform);
-                profileNode.appendNode("properties").appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
-            }
+                profileNode.appendNode("id", "javacpp-platform-host");
+                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.host");
+                propertiesNode = profileNode.appendNode("properties");
+                propertiesNode.appendNode("javacpp.platform", "${os.name}-${os.arch}${javacpp.platform.extension}");
+                for (String profilePlatform : platforms) {
+                    propertiesNode.appendNode("javacpp.platform." + profilePlatform, "${os.name}-${os.arch}${javacpp.platform.extension}");
+                }
 
-            for (int i = 0; i < osNameFrom.length; i++) {
-                for (int j = 0; j < osArchFrom.length; j++) {
-                    String[] osArchs = osArchFrom[j].equals(osArchTo[j]) || (j + 1 < osArchTo.length && osArchTo[j].equals(osArchTo[j + 1]))
-                            ? new String[] { osArchFrom[j] }
-                            : new String[] { osArchFrom[j], osArchTo[j] };
-                    for (String osArch : osArchs) {
-                        String platform = osNameTo[i] + "-" + osArchTo[j];
-                        if (platforms.contains(platform)) {
-                            profileNode = profilesNode.appendNode("profile");
-                            profileNode.appendNode("id", "javacpp.platform.custom-" + osNameTo[i] + "-" + osArch);
-                            Node activationNode = profileNode.appendNode("activation");
-                            activationNode.appendNode("property").appendNode("name", "javacpp.platform.host");
-                            Node osNode = activationNode.appendNode("os");
-                            osNode.appendNode(osNameType[i], osNameFrom[i]);
-                            osNode.appendNode("arch", osArch);
-                            profileNode.appendNode("properties").appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
+                profileNode = profilesNode.appendNode("profile");
+                profileNode.appendNode("id", "javacpp.platform.custom-true");
+                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.custom");
+                propertiesNode = profileNode.appendNode("properties");
+                propertiesNode.appendNode("javacpp.platform", "");
+                for (String profilePlatform : platforms) {
+                    propertiesNode.appendNode("javacpp.platform." + profilePlatform, "");
+                }
+
+                profileNode = profilesNode.appendNode("profile");
+                profileNode.appendNode("id", "javacpp-platform-none");
+                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.none");
+                propertiesNode = profileNode.appendNode("properties");
+                propertiesNode.appendNode("javacpp.platform", "");
+                for (String profilePlatform : platforms) {
+                    propertiesNode.appendNode("javacpp.platform." + profilePlatform, "");
+                }
+
+                for (String platform : platforms) {
+                    profileNode = profilesNode.appendNode("profile");
+                    profileNode.appendNode("id", "javacpp-platform-" + platform);
+                    Node activationPropertyNode = profileNode.appendNode("activation").appendNode("property");
+                    activationPropertyNode.appendNode("name", "javacpp.platform");
+                    activationPropertyNode.appendNode("value", platform);
+                    propertiesNode = profileNode.appendNode("properties");
+                    propertiesNode.appendNode("javacpp.platform", platform);
+                    for (String profilePlatform : platforms) {
+                        propertiesNode.appendNode("javacpp.platform." + profilePlatform,
+                                platform == profilePlatform ? "${javacpp.platform}${javacpp.platform.extension}" : "");
+                    }
+                }
+
+                // Profiles to modify the transitive dependencies when picked up from other pom.xml files, for example:
+                // mvn -Djavacpp.platform.custom -Djavacpp.platform.host -Djavacpp.platform.linux-x86_64 -Djavacpp.platform.windows-x86_64 ...
+                for (String platform : platforms) {
+                    profileNode = profilesNode.appendNode("profile");
+                    profileNode.appendNode("id", "javacpp.platform." + platform + "-true");
+                    profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform." + platform);
+                    profileNode.appendNode("properties").appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
+                }
+
+                for (int i = 0; i < osNameFrom.length; i++) {
+                    for (int j = 0; j < osArchFrom.length; j++) {
+                        String[] osArchs = osArchFrom[j].equals(osArchTo[j]) || (j + 1 < osArchTo.length && osArchTo[j].equals(osArchTo[j + 1]))
+                                ? new String[]{osArchFrom[j]}
+                                : new String[]{osArchFrom[j], osArchTo[j]};
+                        for (String osArch : osArchs) {
+                            String platform = osNameTo[i] + "-" + osArchTo[j];
+                            if (platforms.contains(platform)) {
+                                profileNode = profilesNode.appendNode("profile");
+                                profileNode.appendNode("id", "javacpp.platform.custom-" + osNameTo[i] + "-" + osArch);
+                                Node activationNode = profileNode.appendNode("activation");
+                                activationNode.appendNode("property").appendNode("name", "javacpp.platform.host");
+                                Node osNode = activationNode.appendNode("os");
+                                osNode.appendNode(osNameType[i], osNameFrom[i]);
+                                osNode.appendNode("arch", osArch);
+                                profileNode.appendNode("properties").appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
+                            }
                         }
                     }
                 }
-            }
 
-            // Profiles to set the default javacpp.platform property: If someone knows a better way to do this, please do let me know!
-            for (int i = 0; i < osNameFrom.length; i++) {
-                profileNode = profilesNode.appendNode("profile");
-                profileNode.appendNode("id", osNameTo[i]);
-                profileNode.appendNode("activation").appendNode("os").appendNode(osNameType[i], osNameFrom[i]);
-                propertiesNode = profileNode.appendNode("properties");
-                propertiesNode.appendNode("os.kernel", osNameKernel[i]);
-                propertiesNode.appendNode("os.name", osNameTo[i]);
-            }
-
-            for (int i = 0; i < osArchFrom.length; i++) {
-                if (!osArchFrom[i].equals(osArchTo[i])) {
+                // Profiles to set the default javacpp.platform property: If someone knows a better way to do this, please do let me know!
+                for (int i = 0; i < osNameFrom.length; i++) {
                     profileNode = profilesNode.appendNode("profile");
-                    profileNode.appendNode("id", osArchFrom[i]);
-                    profileNode.appendNode("activation").appendNode("os").appendNode("arch", osArchFrom[i]);
-                    profileNode.appendNode("properties").appendNode("os.arch", osArchTo[i]);
+                    profileNode.appendNode("id", osNameTo[i]);
+                    profileNode.appendNode("activation").appendNode("os").appendNode(osNameType[i], osNameFrom[i]);
+                    propertiesNode = profileNode.appendNode("properties");
+                    propertiesNode.appendNode("os.kernel", osNameKernel[i]);
+                    propertiesNode.appendNode("os.name", osNameTo[i]);
+                }
+
+                for (int i = 0; i < osArchFrom.length; i++) {
+                    if (!osArchFrom[i].equals(osArchTo[i])) {
+                        profileNode = profilesNode.appendNode("profile");
+                        profileNode.appendNode("id", osArchFrom[i]);
+                        profileNode.appendNode("activation").appendNode("os").appendNode("arch", osArchFrom[i]);
+                        profileNode.appendNode("properties").appendNode("os.arch", osArchTo[i]);
+                    }
                 }
             }
-        }};
+        };
     }
 }

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildExtension.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildExtension.java
@@ -58,8 +58,8 @@ public class BuildExtension {
 
     BuildPlugin plugin;
     Project project;
-	
-	static {
+
+    static {
         boolean legacyCheck;
         Constructor<FileBasedMavenArtifact> compatibleConstructor;
         try {

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildExtension.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildExtension.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * @author Samuel Audet
  */
 public class BuildExtension {
-	private static final Constructor<FileBasedMavenArtifact> compatibleArtifactConstructor;
+    private static final Constructor<FileBasedMavenArtifact> compatibleArtifactConstructor;
     private static final boolean isLegacy;
     private final Logger logger = LoggerFactory.getLogger(BuildExtension.class);
 

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildExtension.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildExtension.java
@@ -22,6 +22,14 @@
 package org.bytedeco.gradle.javacpp;
 
 import groovy.util.Node;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.XmlProvider;
@@ -38,28 +46,20 @@ import org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Provides helper methods intended to be used with the "maven-publish" plugin.
  *
  * @author Samuel Audet
  */
 public class BuildExtension {
-    private static final Constructor<FileBasedMavenArtifact> compatibleArtifactConstructor;
+	private static final Constructor<FileBasedMavenArtifact> compatibleArtifactConstructor;
     private static final boolean isLegacy;
     private final Logger logger = LoggerFactory.getLogger(BuildExtension.class);
+
     BuildPlugin plugin;
     Project project;
-
-    static {
+	
+	static {
         boolean legacyCheck;
         Constructor<FileBasedMavenArtifact> compatibleConstructor;
         try {
@@ -105,7 +105,7 @@ public class BuildExtension {
             // Temporarily rename our project to prevent Gradle from resolving the artifacts to project dependencies without files.
             Field nameField = DefaultProject.class.getDeclaredField("name");
             nameField.setAccessible(true);
-            String name = (String) nameField.get(project);
+            String name = (String)nameField.get(project);
             nameField.set(project, name + "-renamed");
             for (ResolvedDependency rd : configuration.getResolvedConfiguration().getLenientConfiguration().getFirstLevelModuleDependencies()) {
                 if (rd.getModuleGroup().equals(project.getGroup()) && rd.getModuleName().equals(name)) {
@@ -133,174 +133,169 @@ public class BuildExtension {
         return artifacts;
     }
 
-    /**
-     * Returns {@code xmlAction(configuration, null)}.
-     */
+    /** Returns {@code xmlAction(configuration, null)}. */
     public Action<? extends XmlProvider> xmlAction(Configuration configuration) {
         return xmlAction(configuration, null);
     }
-
     /**
      * Returns object to be called with {@link MavenPom#withXml(Action)} to create a pom.xml file for "-platform" artifacts.
      *
      * @param configuration containing dependencies to use
-     * @param extension     like "-gpl", "-gpu", "-python", etc (optional)
+     * @param extension like "-gpl", "-gpu", "-python", etc (optional)
      * @return an {@link Action} that fills up an {@link XmlProvider}
      * @see PlatformPlugin
      * @see <a href="https://github.com/bytedeco/javacpp-presets/wiki/Reducing-the-Number-of-Dependencies">Reducing the Number of Dependencies</a>
      */
     public Action<? extends XmlProvider> xmlAction(final Configuration configuration, final String extension) {
-        return new Action<XmlProvider>() {
-            public void execute(XmlProvider xml) {
-                String[] allPlatforms = {"android-arm", "android-arm64", "android-x86", "android-x86_64",
-                        "ios-arm", "ios-arm64", "ios-x86", "ios-x86_64",
-                        "linux-armhf", "linux-arm64", "linux-ppc64le", "linux-x86", "linux-x86_64",
-                        "macosx-arm64", "macosx-x86_64", "windows-x86", "windows-x86_64"};
+        return new Action<XmlProvider>() { public void execute(XmlProvider xml) {
+            String[] allPlatforms = {"android-arm", "android-arm64", "android-x86", "android-x86_64",
+                                     "ios-arm", "ios-arm64", "ios-x86", "ios-x86_64",
+                                     "linux-armhf", "linux-arm64", "linux-ppc64le", "linux-x86", "linux-x86_64",
+                                     "macosx-arm64", "macosx-x86_64", "windows-x86", "windows-x86_64"};
 
-                String[] osNameFrom = {"linux", "mac os x", "windows"};
-                String[] osNameKernel = {"linux", "darwin", "windows"};
-                String[] osNameType = {"name", "name", "family"};
-                String[] osNameTo = {"linux", "macosx", "windows"};
+            String[] osNameFrom = {"linux", "mac os x", "windows"};
+            String[] osNameKernel = {"linux", "darwin", "windows"};
+            String[] osNameType = {"name", "name", "family"};
+            String[] osNameTo = {"linux", "macosx", "windows"};
 
-                String[] osArchFrom = {"arm", "aarch64", "armv8", "ppc64le", "i386", "i486", "i586", "i686", "amd64", "x86-64"};
-                String[] osArchTo = {"armhf", "arm64", "arm64", "ppc64le", "x86", "x86", "x86", "x86", "x86_64", "x86_64"};
+            String[] osArchFrom = {"arm", "aarch64", "armv8", "ppc64le", "i386", "i486", "i586", "i686", "amd64", "x86-64"};
+            String[] osArchTo = {"armhf", "arm64", "arm64", "ppc64le", "x86", "x86", "x86", "x86", "x86_64", "x86_64"};
 
-                ArrayList<String> platforms = new ArrayList<String>();
-                Node propertiesNode = xml.asNode().appendNode("properties");
-                Node dependenciesNode = xml.asNode().appendNode("dependencies");
-                for (ResolvedDependency rd : configuration.getResolvedConfiguration().getLenientConfiguration().getFirstLevelModuleDependencies()) {
-                    if (rd.getModuleGroup().equals(project.getGroup()) && rd.getModuleName().equals(project.getName())) {
-                        Node dependencyNode = dependenciesNode.appendNode("dependency");
-                        dependencyNode.appendNode("groupId", rd.getModuleGroup());
-                        dependencyNode.appendNode("artifactId", rd.getModuleName());
-                        dependencyNode.appendNode("version", rd.getModuleVersion());
-                    }
-                    for (ResolvedArtifact ra : rd.getModuleArtifacts()) {
-                        Node dependencyNode = dependenciesNode.appendNode("dependency");
-                        dependencyNode.appendNode("groupId", rd.getModuleGroup());
-                        dependencyNode.appendNode("artifactId", rd.getModuleName());
-                        dependencyNode.appendNode("version", rd.getModuleVersion());
-                        if (ra.getClassifier() != null) {
-                            String platform = ra.getClassifier();
-                            if (extension != null && platform.endsWith(extension)) {
-                                platform = platform.substring(0, platform.length() - extension.length());
-                            }
-                            dependencyNode.appendNode("classifier", "${javacpp.platform." + platform + "}");
-                            platforms.add(platform);
+            ArrayList<String> platforms = new ArrayList<String>();
+            Node propertiesNode = xml.asNode().appendNode("properties");
+            Node dependenciesNode = xml.asNode().appendNode("dependencies");
+            for (ResolvedDependency rd : configuration.getResolvedConfiguration().getLenientConfiguration().getFirstLevelModuleDependencies()) {
+                if (rd.getModuleGroup().equals(project.getGroup()) && rd.getModuleName().equals(project.getName())) {
+                    Node dependencyNode = dependenciesNode.appendNode("dependency");
+                    dependencyNode.appendNode("groupId", rd.getModuleGroup());
+                    dependencyNode.appendNode("artifactId", rd.getModuleName());
+                    dependencyNode.appendNode("version", rd.getModuleVersion());
+                }
+                for (ResolvedArtifact ra : rd.getModuleArtifacts()) {
+                    Node dependencyNode = dependenciesNode.appendNode("dependency");
+                    dependencyNode.appendNode("groupId", rd.getModuleGroup());
+                    dependencyNode.appendNode("artifactId", rd.getModuleName());
+                    dependencyNode.appendNode("version", rd.getModuleVersion());
+                    if (ra.getClassifier() != null) {
+                        String platform = ra.getClassifier();
+                        if (extension != null && platform.endsWith(extension)) {
+                            platform = platform.substring(0, platform.length() - extension.length());
                         }
-                    }
-                }
-
-                propertiesNode.appendNode("javacpp.platform.extension", extension != null ? extension : "");
-                for (String platform : platforms) {
-                    propertiesNode.appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
-                }
-
-                Node profilesNode = xml.asNode().appendNode("profiles");
-                Node profileNode = profilesNode.appendNode("profile");
-                profileNode.appendNode("id", "javacpp-platform-default");
-                profileNode.appendNode("activation").appendNode("property").appendNode("name", "!javacpp.platform");
-                propertiesNode = profileNode.appendNode("properties");
-                propertiesNode.appendNode("javacpp.platform", "${os.name}-${os.arch}");
-
-                profileNode = profilesNode.appendNode("profile");
-                profileNode.appendNode("id", "javacpp-platform-custom");
-                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform");
-                propertiesNode = profileNode.appendNode("properties");
-                for (String profilePlatform : platforms) {
-                    propertiesNode.appendNode("javacpp.platform." + profilePlatform, "${javacpp.platform}${javacpp.platform.extension}");
-                }
-
-                profileNode = profilesNode.appendNode("profile");
-                profileNode.appendNode("id", "javacpp-platform-host");
-                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.host");
-                propertiesNode = profileNode.appendNode("properties");
-                propertiesNode.appendNode("javacpp.platform", "${os.name}-${os.arch}${javacpp.platform.extension}");
-                for (String profilePlatform : platforms) {
-                    propertiesNode.appendNode("javacpp.platform." + profilePlatform, "${os.name}-${os.arch}${javacpp.platform.extension}");
-                }
-
-                profileNode = profilesNode.appendNode("profile");
-                profileNode.appendNode("id", "javacpp.platform.custom-true");
-                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.custom");
-                propertiesNode = profileNode.appendNode("properties");
-                propertiesNode.appendNode("javacpp.platform", "");
-                for (String profilePlatform : platforms) {
-                    propertiesNode.appendNode("javacpp.platform." + profilePlatform, "");
-                }
-
-                profileNode = profilesNode.appendNode("profile");
-                profileNode.appendNode("id", "javacpp-platform-none");
-                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.none");
-                propertiesNode = profileNode.appendNode("properties");
-                propertiesNode.appendNode("javacpp.platform", "");
-                for (String profilePlatform : platforms) {
-                    propertiesNode.appendNode("javacpp.platform." + profilePlatform, "");
-                }
-
-                for (String platform : platforms) {
-                    profileNode = profilesNode.appendNode("profile");
-                    profileNode.appendNode("id", "javacpp-platform-" + platform);
-                    Node activationPropertyNode = profileNode.appendNode("activation").appendNode("property");
-                    activationPropertyNode.appendNode("name", "javacpp.platform");
-                    activationPropertyNode.appendNode("value", platform);
-                    propertiesNode = profileNode.appendNode("properties");
-                    propertiesNode.appendNode("javacpp.platform", platform);
-                    for (String profilePlatform : platforms) {
-                        propertiesNode.appendNode("javacpp.platform." + profilePlatform,
-                                platform == profilePlatform ? "${javacpp.platform}${javacpp.platform.extension}" : "");
-                    }
-                }
-
-                // Profiles to modify the transitive dependencies when picked up from other pom.xml files, for example:
-                // mvn -Djavacpp.platform.custom -Djavacpp.platform.host -Djavacpp.platform.linux-x86_64 -Djavacpp.platform.windows-x86_64 ...
-                for (String platform : platforms) {
-                    profileNode = profilesNode.appendNode("profile");
-                    profileNode.appendNode("id", "javacpp.platform." + platform + "-true");
-                    profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform." + platform);
-                    profileNode.appendNode("properties").appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
-                }
-
-                for (int i = 0; i < osNameFrom.length; i++) {
-                    for (int j = 0; j < osArchFrom.length; j++) {
-                        String[] osArchs = osArchFrom[j].equals(osArchTo[j]) || (j + 1 < osArchTo.length && osArchTo[j].equals(osArchTo[j + 1]))
-                                ? new String[]{osArchFrom[j]}
-                                : new String[]{osArchFrom[j], osArchTo[j]};
-                        for (String osArch : osArchs) {
-                            String platform = osNameTo[i] + "-" + osArchTo[j];
-                            if (platforms.contains(platform)) {
-                                profileNode = profilesNode.appendNode("profile");
-                                profileNode.appendNode("id", "javacpp.platform.custom-" + osNameTo[i] + "-" + osArch);
-                                Node activationNode = profileNode.appendNode("activation");
-                                activationNode.appendNode("property").appendNode("name", "javacpp.platform.host");
-                                Node osNode = activationNode.appendNode("os");
-                                osNode.appendNode(osNameType[i], osNameFrom[i]);
-                                osNode.appendNode("arch", osArch);
-                                profileNode.appendNode("properties").appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
-                            }
-                        }
-                    }
-                }
-
-                // Profiles to set the default javacpp.platform property: If someone knows a better way to do this, please do let me know!
-                for (int i = 0; i < osNameFrom.length; i++) {
-                    profileNode = profilesNode.appendNode("profile");
-                    profileNode.appendNode("id", osNameTo[i]);
-                    profileNode.appendNode("activation").appendNode("os").appendNode(osNameType[i], osNameFrom[i]);
-                    propertiesNode = profileNode.appendNode("properties");
-                    propertiesNode.appendNode("os.kernel", osNameKernel[i]);
-                    propertiesNode.appendNode("os.name", osNameTo[i]);
-                }
-
-                for (int i = 0; i < osArchFrom.length; i++) {
-                    if (!osArchFrom[i].equals(osArchTo[i])) {
-                        profileNode = profilesNode.appendNode("profile");
-                        profileNode.appendNode("id", osArchFrom[i]);
-                        profileNode.appendNode("activation").appendNode("os").appendNode("arch", osArchFrom[i]);
-                        profileNode.appendNode("properties").appendNode("os.arch", osArchTo[i]);
+                        dependencyNode.appendNode("classifier", "${javacpp.platform." + platform + "}");
+                        platforms.add(platform);
                     }
                 }
             }
-        };
+
+            propertiesNode.appendNode("javacpp.platform.extension", extension != null ? extension : "");
+            for (String platform : platforms) {
+                propertiesNode.appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
+            }
+
+            Node profilesNode = xml.asNode().appendNode("profiles");
+            Node profileNode = profilesNode.appendNode("profile");
+            profileNode.appendNode("id", "javacpp-platform-default");
+            profileNode.appendNode("activation").appendNode("property").appendNode("name", "!javacpp.platform");
+            propertiesNode = profileNode.appendNode("properties");
+            propertiesNode.appendNode("javacpp.platform", "${os.name}-${os.arch}");
+
+            profileNode = profilesNode.appendNode("profile");
+            profileNode.appendNode("id", "javacpp-platform-custom");
+            profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform");
+            propertiesNode = profileNode.appendNode("properties");
+            for (String profilePlatform : platforms) {
+                propertiesNode.appendNode("javacpp.platform." + profilePlatform, "${javacpp.platform}${javacpp.platform.extension}");
+            }
+
+            profileNode = profilesNode.appendNode("profile");
+            profileNode.appendNode("id", "javacpp-platform-host");
+            profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.host");
+            propertiesNode = profileNode.appendNode("properties");
+            propertiesNode.appendNode("javacpp.platform", "${os.name}-${os.arch}${javacpp.platform.extension}");
+            for (String profilePlatform : platforms) {
+                propertiesNode.appendNode("javacpp.platform." + profilePlatform, "${os.name}-${os.arch}${javacpp.platform.extension}");
+            }
+
+            profileNode = profilesNode.appendNode("profile");
+            profileNode.appendNode("id", "javacpp.platform.custom-true");
+            profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.custom");
+            propertiesNode = profileNode.appendNode("properties");
+            propertiesNode.appendNode("javacpp.platform", "");
+            for (String profilePlatform : platforms) {
+                propertiesNode.appendNode("javacpp.platform." + profilePlatform, "");
+            }
+
+            profileNode = profilesNode.appendNode("profile");
+            profileNode.appendNode("id", "javacpp-platform-none");
+            profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform.none");
+            propertiesNode = profileNode.appendNode("properties");
+            propertiesNode.appendNode("javacpp.platform", "");
+            for (String profilePlatform : platforms) {
+                propertiesNode.appendNode("javacpp.platform." + profilePlatform, "");
+            }
+
+            for (String platform : platforms) {
+                profileNode = profilesNode.appendNode("profile");
+                profileNode.appendNode("id", "javacpp-platform-" + platform);
+                Node activationPropertyNode = profileNode.appendNode("activation").appendNode("property");
+                activationPropertyNode.appendNode("name", "javacpp.platform");
+                activationPropertyNode.appendNode("value", platform);
+                propertiesNode = profileNode.appendNode("properties");
+                propertiesNode.appendNode("javacpp.platform", platform);
+                for (String profilePlatform : platforms) {
+                    propertiesNode.appendNode("javacpp.platform." + profilePlatform,
+                            platform == profilePlatform ? "${javacpp.platform}${javacpp.platform.extension}" : "");
+                }
+            }
+
+            // Profiles to modify the transitive dependencies when picked up from other pom.xml files, for example:
+            // mvn -Djavacpp.platform.custom -Djavacpp.platform.host -Djavacpp.platform.linux-x86_64 -Djavacpp.platform.windows-x86_64 ...
+            for (String platform : platforms) {
+                profileNode = profilesNode.appendNode("profile");
+                profileNode.appendNode("id", "javacpp.platform." + platform + "-true");
+                profileNode.appendNode("activation").appendNode("property").appendNode("name", "javacpp.platform." + platform);
+                profileNode.appendNode("properties").appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
+            }
+
+            for (int i = 0; i < osNameFrom.length; i++) {
+                for (int j = 0; j < osArchFrom.length; j++) {
+                    String[] osArchs = osArchFrom[j].equals(osArchTo[j]) || (j + 1 < osArchTo.length && osArchTo[j].equals(osArchTo[j + 1]))
+                            ? new String[] { osArchFrom[j] }
+                            : new String[] { osArchFrom[j], osArchTo[j] };
+                    for (String osArch : osArchs) {
+                        String platform = osNameTo[i] + "-" + osArchTo[j];
+                        if (platforms.contains(platform)) {
+                            profileNode = profilesNode.appendNode("profile");
+                            profileNode.appendNode("id", "javacpp.platform.custom-" + osNameTo[i] + "-" + osArch);
+                            Node activationNode = profileNode.appendNode("activation");
+                            activationNode.appendNode("property").appendNode("name", "javacpp.platform.host");
+                            Node osNode = activationNode.appendNode("os");
+                            osNode.appendNode(osNameType[i], osNameFrom[i]);
+                            osNode.appendNode("arch", osArch);
+                            profileNode.appendNode("properties").appendNode("javacpp.platform." + platform, platform + "${javacpp.platform.extension}");
+                        }
+                    }
+                }
+            }
+
+            // Profiles to set the default javacpp.platform property: If someone knows a better way to do this, please do let me know!
+            for (int i = 0; i < osNameFrom.length; i++) {
+                profileNode = profilesNode.appendNode("profile");
+                profileNode.appendNode("id", osNameTo[i]);
+                profileNode.appendNode("activation").appendNode("os").appendNode(osNameType[i], osNameFrom[i]);
+                propertiesNode = profileNode.appendNode("properties");
+                propertiesNode.appendNode("os.kernel", osNameKernel[i]);
+                propertiesNode.appendNode("os.name", osNameTo[i]);
+            }
+
+            for (int i = 0; i < osArchFrom.length; i++) {
+                if (!osArchFrom[i].equals(osArchTo[i])) {
+                    profileNode = profilesNode.appendNode("profile");
+                    profileNode.appendNode("id", osArchFrom[i]);
+                    profileNode.appendNode("activation").appendNode("os").appendNode("arch", osArchFrom[i]);
+                    profileNode.appendNode("properties").appendNode("os.arch", osArchTo[i]);
+                }
+            }
+        }};
     }
 }

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -270,7 +270,7 @@ public class BuildPlugin implements Plugin<Project> {
             TaskProvider<Jar> javacppPlatformJavadocJarTask = project.getTasks().register("javacppPlatformJavadocJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
                 setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
-                setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                setProperty("setClassifier", "getArchiveClassifier", task, "javadoc");
                 task.dependsOn("javacppPlatformJar");
             }});
 

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -131,7 +131,7 @@ public class BuildPlugin implements Plugin<Project> {
                     JavaCompile.class, new Action<JavaCompile>() { public void execute(JavaCompile task) {
                 task.setSource(main.getJava());
                 task.setClasspath(main.getCompileClasspath());
-                task.getDestinationDirectory().set(main.getJava().getClassesDirectory());
+                task.setDestinationDir(main.getJava().getOutputDir());
                 task.dependsOn("javacppBuildCommand");
             }});
 
@@ -185,7 +185,7 @@ public class BuildPlugin implements Plugin<Project> {
             TaskProvider<Jar> javacppJarTask = project.getTasks().register("javacppJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
                 task.from(main.getOutput());
-                task.getArchiveClassifier().set(getPlatform() + getPlatformExtension());
+                task.setClassifier(getPlatform() + getPlatformExtension());
                 task.include(new Spec<FileTreeElement>() { public boolean isSatisfiedBy(FileTreeElement file) {
                     return file.isDirectory() || isLibraryPath(file.getPath());
                 }});
@@ -196,21 +196,21 @@ public class BuildPlugin implements Plugin<Project> {
 
             TaskProvider<Jar> javacppPlatformJarTask = project.getTasks().register("javacppPlatformJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.getArchiveBaseName().set(project.getName() + "-platform");
+                task.setBaseName(project.getName() + "-platform");
                 task.dependsOn("javacppJar");
             }});
 
             TaskProvider<Jar> javacppPlatformJavadocJarTask = project.getTasks().register("javacppPlatformJavadocJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.getArchiveBaseName().set(project.getName() + "-platform");
-                task.getArchiveClassifier().set("javadoc");
+                task.setBaseName(project.getName() + "-platform");
+                task.setClassifier("javadoc");
                 task.dependsOn("javacppPlatformJar");
             }});
 
             TaskProvider<Jar> javacppPlatformSourcesTask = project.getTasks().register("javacppPlatformSourcesJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.getArchiveBaseName().set(project.getName() + "-platform");
-                task.getArchiveClassifier().set("sources");
+                task.setBaseName(project.getName() + "-platform");
+                task.setClassifier("sources");
                 task.dependsOn("javacppPlatformJar");
             }});
 

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -92,7 +92,7 @@ public class BuildPlugin implements Plugin<Project> {
         String p = (String)project.findProperty("javacpp.platform.library.path");
         return p != null && p.length() > 0 ? path.startsWith(p) : path.contains("/" + getPlatform() + getPlatformExtension() + "/");
     }
-	
+
     private <T> void setProperty(String originalMethod, String propertyField, Object target, T value) {
         Method method = findMethod(target.getClass(), originalMethod, value.getClass());
         if (method != null) {
@@ -146,7 +146,7 @@ public class BuildPlugin implements Plugin<Project> {
             throw new RuntimeException(e);
         }
     }
-	
+
     @Override public void apply(final Project project) {
         this.project = project;
         if (!project.hasProperty("javacppPlatform")) {

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -190,12 +190,12 @@ public class BuildPlugin implements Plugin<Project> {
                 task.setSource(main.getJava());
                 task.setClasspath(main.getCompileClasspath());
                 setProperty(
-                    "setDestinationDir",
-                    "getDestinationDirectory",
+                    "setDestinationDir", // Deprecated in 7.1, will be removed in Gradle 9.0
+                    "getDestinationDirectory", // Since 6.1
                     task,
                     getProperty(
-                        "getOutputDir",
-                        "getClassesDirectory",
+                        "getOutputDir", // Deprecated in 7.1, removed in Gradle 8.0
+                        "getClassesDirectory", // Since 6.1
                         main.getJava()
                     )
                 );
@@ -252,7 +252,11 @@ public class BuildPlugin implements Plugin<Project> {
             TaskProvider<Jar> javacppJarTask = project.getTasks().register("javacppJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
                 task.from(main.getOutput());
-                setProperty("setClassifier", "getArchiveClassifier", task, getPlatform() + getPlatformExtension());
+                setProperty(
+                    "setClassifier", // Deprecated in 7.0, removed in 8.0
+                    "getArchiveClassifier", // Since 5.1
+                    task,
+                    getPlatform() + getPlatformExtension());
                 task.include(new Spec<FileTreeElement>() { public boolean isSatisfiedBy(FileTreeElement file) {
                     return file.isDirectory() || isLibraryPath(file.getPath());
                 }});
@@ -263,20 +267,36 @@ public class BuildPlugin implements Plugin<Project> {
 
             TaskProvider<Jar> javacppPlatformJarTask = project.getTasks().register("javacppPlatformJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                setProperty(
+                    "setBaseName", // Deprecated in 7.0, removed in 8.0
+                    "getArchiveBaseName", // Since 5.1
+                    task, 
+                    project.getName() + "-platform");
                 task.dependsOn("javacppJar");
             }});
 
             TaskProvider<Jar> javacppPlatformJavadocJarTask = project.getTasks().register("javacppPlatformJavadocJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
-                setProperty("setClassifier", "getArchiveClassifier", task, "javadoc");
+                setProperty(
+                    "setBaseName", // Deprecated in 7.0, removed in 8.0
+                    "getArchiveBaseName", // Since 5.1
+                    task,
+                    project.getName() + "-platform");
+                setProperty(
+                    "setClassifier", // Deprecated in 7.0, removed in 8.0
+                    "getArchiveClassifier", // Since 5.1
+                    task,
+                    "javadoc");
                 task.dependsOn("javacppPlatformJar");
             }});
 
             TaskProvider<Jar> javacppPlatformSourcesTask = project.getTasks().register("javacppPlatformSourcesJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                setProperty(
+                    "setBaseName", // Deprecated in 7.0, removed in 8.0
+                    "getArchiveBaseName", // Since 5.1
+                    task,
+                    project.getName() + "-platform");
                 setProperty("setClassifier", "getArchiveClassifier", task, "sources");
                 task.dependsOn("javacppPlatformJar");
             }});

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -195,7 +195,7 @@ public class BuildPlugin implements Plugin<Project> {
                     task,
                     getProperty(
                         "getOutputDir",
-                        "getDestinationDirectory",
+                        "getClassesDirectory",
                         main.getJava()
                     )
                 );

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -131,7 +131,7 @@ public class BuildPlugin implements Plugin<Project> {
                     JavaCompile.class, new Action<JavaCompile>() { public void execute(JavaCompile task) {
                 task.setSource(main.getJava());
                 task.setClasspath(main.getCompileClasspath());
-                task.setDestinationDir(main.getJava().getOutputDir());
+                task.getDestinationDirectory().set(main.getJava().getClassesDirectory());
                 task.dependsOn("javacppBuildCommand");
             }});
 
@@ -185,7 +185,7 @@ public class BuildPlugin implements Plugin<Project> {
             TaskProvider<Jar> javacppJarTask = project.getTasks().register("javacppJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
                 task.from(main.getOutput());
-                task.setClassifier(getPlatform() + getPlatformExtension());
+                task.getArchiveClassifier().set(getPlatform() + getPlatformExtension());
                 task.include(new Spec<FileTreeElement>() { public boolean isSatisfiedBy(FileTreeElement file) {
                     return file.isDirectory() || isLibraryPath(file.getPath());
                 }});
@@ -196,21 +196,21 @@ public class BuildPlugin implements Plugin<Project> {
 
             TaskProvider<Jar> javacppPlatformJarTask = project.getTasks().register("javacppPlatformJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.setBaseName(project.getName() + "-platform");
+                task.getArchiveBaseName().set(project.getName() + "-platform");
                 task.dependsOn("javacppJar");
             }});
 
             TaskProvider<Jar> javacppPlatformJavadocJarTask = project.getTasks().register("javacppPlatformJavadocJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.setBaseName(project.getName() + "-platform");
-                task.setClassifier("javadoc");
+                task.getArchiveBaseName().set(project.getName() + "-platform");
+                task.getArchiveClassifier().set("javadoc");
                 task.dependsOn("javacppPlatformJar");
             }});
 
             TaskProvider<Jar> javacppPlatformSourcesTask = project.getTasks().register("javacppPlatformSourcesJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.setBaseName(project.getName() + "-platform");
-                task.setClassifier("sources");
+                task.getArchiveBaseName().set(project.getName() + "-platform");
+                task.getArchiveClassifier().set("sources");
                 task.dependsOn("javacppPlatformJar");
             }});
 

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -23,6 +23,8 @@ package org.bytedeco.gradle.javacpp;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Properties;
 import java.util.Set;
 import org.bytedeco.javacpp.Loader;
@@ -33,6 +35,7 @@ import org.gradle.api.Task;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Property;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
@@ -89,6 +92,49 @@ public class BuildPlugin implements Plugin<Project> {
         return p != null && p.length() > 0 ? path.startsWith(p) : path.contains("/" + getPlatform() + getPlatformExtension() + "/");
     }
 
+    private <T> void setProperty(String originalMethod, String propertyField, Object target, T value) {
+        Method method = findMethod(target.getClass(), originalMethod);
+        if (method != null) {
+            invoke(method, target);
+        } else {
+            Method propertyGetter = findMethod(target.getClass(), propertyField);
+            if (propertyGetter == null) {
+                throw new RuntimeException("Cannot find property getter method " + propertyField + " in " + target.getClass());
+            }
+            ((Property<T>) invoke(propertyGetter, target)).set(value);
+        }
+    }
+
+    private <T> T getProperty(String originalMethod, String propertyMethod, Object target) {
+        Method method = findMethod(target.getClass(), originalMethod);
+        if (method != null) {
+            return (T) invoke(method, target);
+        }
+        Method propertyGetter = findMethod(target.getClass(), propertyMethod);
+        if (propertyGetter == null) {
+            throw new RuntimeException("Cannot find property getter method " + propertyMethod + " in " + target.getClass());
+        }
+        return ((Property<T>) invoke(propertyGetter, target)).get();
+    }
+
+
+    private Method findMethod(Class<?> cls, String methodName) {
+        for (Method method : cls.getMethods()) {
+            if (method.getName().equals(methodName)) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    private <T> T invoke(Method method, Object target, Object... parameter) {
+        try {
+            return (T) method.invoke(target, parameter);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override public void apply(final Project project) {
         this.project = project;
         if (!project.hasProperty("javacppPlatform")) {
@@ -117,64 +163,73 @@ public class BuildPlugin implements Plugin<Project> {
 
             project.getTasks().register("javacppBuildCommand",
                     BuildTask.class, new Action<BuildTask>() { public void execute(BuildTask task) {
-                task.classPath = paths;
-                task.properties = getPlatform();
-                if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
-                    task.propertyKeysAndValues = new Properties();
-                    task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
-                }
-                task.classOrPackageNames = new String[0];
-                task.workingDirectory = project.getProjectDir();
-            }});
+                        task.classPath = paths;
+                        task.properties = getPlatform();
+                        if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
+                            task.propertyKeysAndValues = new Properties();
+                            task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
+                        }
+                        task.classOrPackageNames = new String[0];
+                        task.workingDirectory = project.getProjectDir();
+                    }});
 
             project.getTasks().register("javacppCompileJava",
                     JavaCompile.class, new Action<JavaCompile>() { public void execute(JavaCompile task) {
-                task.setSource(main.getJava());
-                task.setClasspath(main.getCompileClasspath());
-                task.setDestinationDir(main.getJava().getOutputDir());
-                task.dependsOn("javacppBuildCommand");
-            }});
+                        task.setSource(main.getJava());
+                        task.setClasspath(main.getCompileClasspath());
+                        setProperty(
+                                "getDestinationDirectory",
+                                "setDestinationDir",
+                                task,
+                                getProperty(
+                                        "getOutputDir",
+                                        "getDestinationDirectory",
+                                        main.getJava()
+                                )
+                        );
+                        task.dependsOn("javacppBuildCommand");
+                    }});
 
             project.getTasks().register("javacppBuildParser",
                     BuildTask.class, new Action<BuildTask>() { public void execute(final BuildTask task) {
-                task.classPath = paths;
-                task.properties = getPlatform();
-                if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
-                    task.propertyKeysAndValues = new Properties();
-                    task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
-                }
-                if (task.outputDirectory == null) {
-                    task.outputDirectory = main.getJava().getSrcDirs().iterator().next();
-                }
-                task.dependsOn("javacppCompileJava");
-                task.doFirst(new Action<Task>() { public void execute(Task t) { main.getJava().srcDir(task.outputDirectory); }});
-            }});
+                        task.classPath = paths;
+                        task.properties = getPlatform();
+                        if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
+                            task.propertyKeysAndValues = new Properties();
+                            task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
+                        }
+                        if (task.outputDirectory == null) {
+                            task.outputDirectory = main.getJava().getSrcDirs().iterator().next();
+                        }
+                        task.dependsOn("javacppCompileJava");
+                        task.doFirst(new Action<Task>() { public void execute(Task t) { main.getJava().srcDir(task.outputDirectory); }});
+                    }});
 
             project.getTasks().getByName("compileJava").dependsOn("javacppBuildParser");
 
             project.getTasks().register("javacppBuildCompiler",
                     BuildTask.class, new Action<BuildTask>() { public void execute(BuildTask task) {
-                task.classPath = paths;
-                task.properties = getPlatform();
-                if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
-                    task.propertyKeysAndValues = new Properties();
-                    task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
-                }
-                task.dependsOn("compileJava");
-            }});
+                        task.classPath = paths;
+                        task.properties = getPlatform();
+                        if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
+                            task.propertyKeysAndValues = new Properties();
+                            task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
+                        }
+                        task.dependsOn("compileJava");
+                    }});
 
             project.getTasks().getByName("classes").dependsOn("javacppBuildCompiler");
 
             project.getTasks().register("javacppPomProperties",
                     WriteProperties.class, new Action<WriteProperties>() { public void execute(WriteProperties task) {
-                Object group = project.findProperty("group");
-                Object name = project.findProperty("name");
-                Object version = project.findProperty("version");
-                task.property("groupId", group);
-                task.property("artifactId", name);
-                task.property("version", version);
-                task.setOutputFile(new File(main.getOutput().getResourcesDir(), "META-INF/maven/" + group + "/" + name + "/pom.properties"));
-            }});
+                        Object group = project.findProperty("group");
+                        Object name = project.findProperty("name");
+                        Object version = project.findProperty("version");
+                        task.property("groupId", group);
+                        task.property("artifactId", name);
+                        task.property("version", version);
+                        task.setOutputFile(new File(main.getOutput().getResourcesDir(), "META-INF/maven/" + group + "/" + name + "/pom.properties"));
+                    }});
 
             Jar jarTask = (Jar)project.getTasks().getByName("jar");
             jarTask.dependsOn("javacppPomProperties");
@@ -184,35 +239,35 @@ public class BuildPlugin implements Plugin<Project> {
 
             TaskProvider<Jar> javacppJarTask = project.getTasks().register("javacppJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.from(main.getOutput());
-                task.setClassifier(getPlatform() + getPlatformExtension());
-                task.include(new Spec<FileTreeElement>() { public boolean isSatisfiedBy(FileTreeElement file) {
-                    return file.isDirectory() || isLibraryPath(file.getPath());
-                }});
-                task.dependsOn("jar");
-            }});
+                        task.from(main.getOutput());
+                        setProperty("setClassifier", "getArchiveClassifier", task, getPlatform() + getPlatformExtension());
+                        task.include(new Spec<FileTreeElement>() { public boolean isSatisfiedBy(FileTreeElement file) {
+                            return file.isDirectory() || isLibraryPath(file.getPath());
+                        }});
+                        task.dependsOn("jar");
+                    }});
 
             project.getArtifacts().add("archives", javacppJarTask);
 
             TaskProvider<Jar> javacppPlatformJarTask = project.getTasks().register("javacppPlatformJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.setBaseName(project.getName() + "-platform");
-                task.dependsOn("javacppJar");
-            }});
+                        setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                        task.dependsOn("javacppJar");
+                    }});
 
             TaskProvider<Jar> javacppPlatformJavadocJarTask = project.getTasks().register("javacppPlatformJavadocJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.setBaseName(project.getName() + "-platform");
-                task.setClassifier("javadoc");
-                task.dependsOn("javacppPlatformJar");
-            }});
+                        setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                        setProperty("setClassifier", "getArchiveClassifier", task, "javadoc");
+                        task.dependsOn("javacppPlatformJar");
+                    }});
 
             TaskProvider<Jar> javacppPlatformSourcesTask = project.getTasks().register("javacppPlatformSourcesJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                task.setBaseName(project.getName() + "-platform");
-                task.setClassifier("sources");
-                task.dependsOn("javacppPlatformJar");
-            }});
+                        setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                        setProperty("setClassifier", "getArchiveClassifier", task, "sources");
+                        task.dependsOn("javacppPlatformJar");
+                    }});
 
             project.getConfigurations().maybeCreate("javacppPlatform");
             project.getArtifacts().add("javacppPlatform", javacppPlatformJarTask);

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -143,8 +143,8 @@ public class BuildPlugin implements Plugin<Project> {
     private <T> T invoke(Method method, Object target, Object... parameter) {
         try {
             return (T) method.invoke(target, parameter);
-        } catch (Exception e) {
-            throw new RuntimeException("Method " + method.getName() + ", types " ,e);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
+++ b/src/main/java/org/bytedeco/gradle/javacpp/BuildPlugin.java
@@ -92,7 +92,7 @@ public class BuildPlugin implements Plugin<Project> {
         String p = (String)project.findProperty("javacpp.platform.library.path");
         return p != null && p.length() > 0 ? path.startsWith(p) : path.contains("/" + getPlatform() + getPlatformExtension() + "/");
     }
-
+	
     private <T> void setProperty(String originalMethod, String propertyField, Object target, T value) {
         Method method = findMethod(target.getClass(), originalMethod, value.getClass());
         if (method != null) {
@@ -122,7 +122,6 @@ public class BuildPlugin implements Plugin<Project> {
         return ((Property<T>) invoke(propertyGetter, target)).get();
     }
 
-
     private Method findMethod(Class<?> cls, String methodName) {
         for (Method method : cls.getMethods()) {
             if (method.getName().equals(methodName)) {
@@ -147,7 +146,7 @@ public class BuildPlugin implements Plugin<Project> {
             throw new RuntimeException(e);
         }
     }
-
+	
     @Override public void apply(final Project project) {
         this.project = project;
         if (!project.hasProperty("javacppPlatform")) {
@@ -176,73 +175,73 @@ public class BuildPlugin implements Plugin<Project> {
 
             project.getTasks().register("javacppBuildCommand",
                     BuildTask.class, new Action<BuildTask>() { public void execute(BuildTask task) {
-                        task.classPath = paths;
-                        task.properties = getPlatform();
-                        if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
-                            task.propertyKeysAndValues = new Properties();
-                            task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
-                        }
-                        task.classOrPackageNames = new String[0];
-                        task.workingDirectory = project.getProjectDir();
-                    }});
+                task.classPath = paths;
+                task.properties = getPlatform();
+                if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
+                    task.propertyKeysAndValues = new Properties();
+                    task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
+                }
+                task.classOrPackageNames = new String[0];
+                task.workingDirectory = project.getProjectDir();
+            }});
 
             project.getTasks().register("javacppCompileJava",
                     JavaCompile.class, new Action<JavaCompile>() { public void execute(JavaCompile task) {
-                        task.setSource(main.getJava());
-                        task.setClasspath(main.getCompileClasspath());
-                        setProperty(
-                                "setDestinationDir",
-                                 "getDestinationDirectory",
-                                task,
-                                getProperty(
-                                        "getOutputDir",
-                                        "getDestinationDirectory",
-                                        main.getJava()
-                                )
-                        );
-                        task.dependsOn("javacppBuildCommand");
-                    }});
+                task.setSource(main.getJava());
+                task.setClasspath(main.getCompileClasspath());
+                setProperty(
+                    "setDestinationDir",
+                    "getDestinationDirectory",
+                    task,
+                    getProperty(
+                        "getOutputDir",
+                        "getDestinationDirectory",
+                        main.getJava()
+                    )
+                );
+                task.dependsOn("javacppBuildCommand");
+            }});
 
             project.getTasks().register("javacppBuildParser",
                     BuildTask.class, new Action<BuildTask>() { public void execute(final BuildTask task) {
-                        task.classPath = paths;
-                        task.properties = getPlatform();
-                        if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
-                            task.propertyKeysAndValues = new Properties();
-                            task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
-                        }
-                        if (task.outputDirectory == null) {
-                            task.outputDirectory = main.getJava().getSrcDirs().iterator().next();
-                        }
-                        task.dependsOn("javacppCompileJava");
-                        task.doFirst(new Action<Task>() { public void execute(Task t) { main.getJava().srcDir(task.outputDirectory); }});
-                    }});
+                task.classPath = paths;
+                task.properties = getPlatform();
+                if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
+                    task.propertyKeysAndValues = new Properties();
+                    task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
+                }
+                if (task.outputDirectory == null) {
+                    task.outputDirectory = main.getJava().getSrcDirs().iterator().next();
+                }
+                task.dependsOn("javacppCompileJava");
+                task.doFirst(new Action<Task>() { public void execute(Task t) { main.getJava().srcDir(task.outputDirectory); }});
+            }});
 
             project.getTasks().getByName("compileJava").dependsOn("javacppBuildParser");
 
             project.getTasks().register("javacppBuildCompiler",
                     BuildTask.class, new Action<BuildTask>() { public void execute(BuildTask task) {
-                        task.classPath = paths;
-                        task.properties = getPlatform();
-                        if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
-                            task.propertyKeysAndValues = new Properties();
-                            task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
-                        }
-                        task.dependsOn("compileJava");
-                    }});
+                task.classPath = paths;
+                task.properties = getPlatform();
+                if (getPlatformExtension() != null && getPlatformExtension().length() > 0) {
+                    task.propertyKeysAndValues = new Properties();
+                    task.propertyKeysAndValues.setProperty("platform.extension", getPlatformExtension());
+                }
+                task.dependsOn("compileJava");
+            }});
 
             project.getTasks().getByName("classes").dependsOn("javacppBuildCompiler");
 
             project.getTasks().register("javacppPomProperties",
                     WriteProperties.class, new Action<WriteProperties>() { public void execute(WriteProperties task) {
-                        Object group = project.findProperty("group");
-                        Object name = project.findProperty("name");
-                        Object version = project.findProperty("version");
-                        task.property("groupId", group);
-                        task.property("artifactId", name);
-                        task.property("version", version);
-                        task.setOutputFile(new File(main.getOutput().getResourcesDir(), "META-INF/maven/" + group + "/" + name + "/pom.properties"));
-                    }});
+                Object group = project.findProperty("group");
+                Object name = project.findProperty("name");
+                Object version = project.findProperty("version");
+                task.property("groupId", group);
+                task.property("artifactId", name);
+                task.property("version", version);
+                task.setOutputFile(new File(main.getOutput().getResourcesDir(), "META-INF/maven/" + group + "/" + name + "/pom.properties"));
+            }});
 
             Jar jarTask = (Jar)project.getTasks().getByName("jar");
             jarTask.dependsOn("javacppPomProperties");
@@ -252,35 +251,35 @@ public class BuildPlugin implements Plugin<Project> {
 
             TaskProvider<Jar> javacppJarTask = project.getTasks().register("javacppJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                        task.from(main.getOutput());
-                        setProperty("setClassifier", "getArchiveClassifier", task, getPlatform() + getPlatformExtension());
-                        task.include(new Spec<FileTreeElement>() { public boolean isSatisfiedBy(FileTreeElement file) {
-                            return file.isDirectory() || isLibraryPath(file.getPath());
-                        }});
-                        task.dependsOn("jar");
-                    }});
+                task.from(main.getOutput());
+                setProperty("setClassifier", "getArchiveClassifier", task, getPlatform() + getPlatformExtension());
+                task.include(new Spec<FileTreeElement>() { public boolean isSatisfiedBy(FileTreeElement file) {
+                    return file.isDirectory() || isLibraryPath(file.getPath());
+                }});
+                task.dependsOn("jar");
+            }});
 
             project.getArtifacts().add("archives", javacppJarTask);
 
             TaskProvider<Jar> javacppPlatformJarTask = project.getTasks().register("javacppPlatformJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                        setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
-                        task.dependsOn("javacppJar");
-                    }});
+                setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                task.dependsOn("javacppJar");
+            }});
 
             TaskProvider<Jar> javacppPlatformJavadocJarTask = project.getTasks().register("javacppPlatformJavadocJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                        setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
-                        setProperty("setClassifier", "getArchiveClassifier", task, "javadoc");
-                        task.dependsOn("javacppPlatformJar");
-                    }});
+                setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                task.dependsOn("javacppPlatformJar");
+            }});
 
             TaskProvider<Jar> javacppPlatformSourcesTask = project.getTasks().register("javacppPlatformSourcesJar",
                     Jar.class, new Action<Jar>() { public void execute(Jar task) {
-                        setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
-                        setProperty("setClassifier", "getArchiveClassifier", task, "sources");
-                        task.dependsOn("javacppPlatformJar");
-                    }});
+                setProperty("setBaseName", "getArchiveBaseName", task, project.getName() + "-platform");
+                setProperty("setClassifier", "getArchiveClassifier", task, "sources");
+                task.dependsOn("javacppPlatformJar");
+            }});
 
             project.getConfigurations().maybeCreate("javacppPlatform");
             project.getArtifacts().add("javacppPlatform", javacppPlatformJarTask);


### PR DESCRIPTION
## Gradle Version Support Updates

### 1. Added Support for Gradle 8
- **Problem:** Gradle 8 removed some methods that were deprecated in previous versions, leading to incompatibility issues.
- **Solution:** [Necessary code changes have been made](https://github.com/milkyway0308/gradle-javacpp/commit/756370dfb85d1d6401e11204ffa6d2431dcdaef8) to ensure compatibility with Gradle 8.

### 2. Introduced Backward Compatibility with Gradle 6
- **Problem:** Gradle 6 introduced some changes in the constructors of specific classes, causing incompatibility with Gradle 6 and newer versions.
- **Solution:** Given the critical nature of this issue, support has been [implemented using reflection](https://github.com/milkyway0308/gradle-javacpp/commit/69b125a1018506849d73332250a73603a4fa0d94) to maintain compatibility with these versions.

### 3. Dropped Support for Gradle 5
- **Reason:** Gradle 5 is an older version with fundamental methods not being compatible with the latest Gradle versions.
- **Solution:** Instead of maintaining backward compatibility through reflection for Gradle 5, changes have been made to utilize methods introduced in Gradle 6 and newer. As a result, once this commit is merged, the project will no longer support Gradle 5.

**Please review the changes and provide feedback.**

This pull request is affected from Issue #30.